### PR TITLE
SBO::Lib::Util: Ignore + suffix on version check

### DIFF
--- a/SBO-Lib/lib/SBO/Lib/Util.pm
+++ b/SBO-Lib/lib/SBO/Lib/Util.pm
@@ -216,7 +216,7 @@ sub get_slack_version {
   }
   chomp(my $line = <$fh>);
   close $fh;
-  my $version = ($line =~ /\s+(\d+[^\s]+)$/)[0];
+  my $version = ($line =~ /\s+(\d+[0-9.]+)\+?$/)[0];
   usage_error("Unsupported Slackware version: $version\n")
     unless $supported{$version};
   return $supported{$version};


### PR DESCRIPTION
The latest iteration of Slackware-current added a plus sign to the suffix
as an indicator for current.

Fixes https://github.com/pink-mist/sbotools/issues/73