### PR TITLE
escape left brace after perl update (solving issue #75)

### DIFF
--- a/SBO-Lib/lib/SBO/Lib/Build.pm
+++ b/SBO-Lib/lib/SBO/Lib/Build.pm
@@ -241,7 +241,7 @@ sub get_dc_regex {
   # convert any instances of command substitution to [^-]+
   $line =~ s/\$\([^)]+\)/[^-]+/g;
   # convert any bash variables to [^-]+
-  $line =~ s/\$({|)[A-Za-z0-9_]+(}|)/[^-]+/g;
+  $line =~ s/\$(\{|)[A-Za-z0-9_]+(}|)/[^-]+/g;
   # get rid of anything excess at the end
   $line =~ s/\s+.*$//;
   # fix .?z* at the end


### PR DESCRIPTION
After the last update of perl from perl-5.26.2 to perl-5.28.0 on the current release, perl is raising the following warning when running sbotools.
> Unescaped left brace in regex is deprecated here (and will be fatal in Perl 5.32), passed through in regex; marked by <-- HERE in m/$({ <-- HERE |)[A-Za-z0-9_]+(}|)/ at /usr/share/perl5/SBO/Lib/Build.pm line 244.