### PR TITLE
config wget maximum trying times to 5 

### DIFF
--- a/SBO-Lib/lib/SBO/Lib/Download.pm
+++ b/SBO-Lib/lib/SBO/Lib/Download.pm
@@ -179,7 +179,7 @@ sub get_distfile {
     substr($info_md5, 0, 1), substr($info_md5, 1, 1), $info_md5, _get_fname($link));
 
   return 1 if
-    system('wget', '--no-check-certificate', $sbosrcarch) == 0 and
+    system('wget', '--no-check-certificate', '--tries=5', $sbosrcarch) == 0 and
     verify_distfile(@_);
 
   return $fail->{msg}, $fail->{err};

--- a/SBO-Lib/lib/SBO/Lib/Download.pm
+++ b/SBO-Lib/lib/SBO/Lib/Download.pm
@@ -161,7 +161,7 @@ sub get_distfile {
 
   #  if wget $link && verify, return
   #  else wget sbosrcarch && verify
-  if (system('wget', '--no-check-certificate', $link) != 0) {
+  if (system('wget', '--no-check-certificate', '--tries=5', $link) != 0) {
     $fail->{msg} = "Unable to wget $link.\n";
     $fail->{err} = _ERR_DOWNLOAD;
   }


### PR DESCRIPTION
The default of `wget` is to try 20 times which costs too long. Maybe it's helpful to add this option when user is behind firewall like me. :-)

Feel free to close this PR if it's not suitable.
