### PR TITLE
SBO::Lib::Pkgs: Fix getting available updates

### DIFF
--- a/SBO-Lib/lib/SBO/Lib/Pkgs.pm
+++ b/SBO-Lib/lib/SBO/Lib/Pkgs.pm
@@ -67,7 +67,7 @@ sub get_available_updates {
         next unless $location;
 
         my $version = get_sbo_version($location);
-        if (version_cmp($version, $pkg->{version}) != 0) {
+        if (version_cmp($version, $pkg->{version}) > 0) {
             push @updates, { name => $pkg->{name}, installed => $pkg->{version}, update => $version };
         }
     }


### PR DESCRIPTION
When comparing package versions, consider only the case when the available
package version is greater than the installed package version to be an update.

Example of the bug case:
```
...

apparmor 3.0.3  <  needs updating (2.13.4 from SBo)
qt5ct 1.5       <  needs updating (1.1 from SBo)

...
```